### PR TITLE
Update Subconverter.vue

### DIFF
--- a/src/views/Subconverter.vue
+++ b/src/views/Subconverter.vue
@@ -537,6 +537,10 @@ export default {
               {
                 label: "ProxyStorage自用",
                 value: "https://raw.githubusercontent.com/ProxyStorage/For-Own-Use/master/Clash/clash.ini"
+              },
+              {
+                label: "ACL_全分组 Dream修改版",
+                value: "https://raw.githubusercontent.com/WC-Dream/ACL4SSR/master/Clash/config/ACL4SSR_Online_Full_Dream.ini"
               }
             ]
           },


### PR DESCRIPTION
新增ACL_全分组 Dream修改版
1、移除去广告、电报消息、网易音乐、油管视频、巴哈姆特、哔哩哔哩的单独分组，更精简
2、移除韩国节点分组，优化香港分组的正则匹配
3、增加DisneyPlus分组
4、Netflix、DisneyPlus分组规则在原来的基础上增加了所有节点，在不需要使用手动选择的情况下便捷选择节点
5、额外增加了1个手动选择的分组，共有2个手动选择，方便特殊需求
6、优化自动切换的阈值，防止切换太频繁