### PR TITLE
Add Dockerfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# ---- Dependencies ----
+FROM node:12-alpine AS dependencies
+WORKDIR /app
+COPY package.json ./
+RUN yarn install
+
+# ---- Build ----
+FROM dependencies AS build
+WORKDIR /app
+COPY . /app
+RUN yarn build
+
+FROM nginx:1.16-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD [ "nginx", "-g", "daemon off;" ]


### PR DESCRIPTION
Add Dockerfile support to build package for production

Usage: 
`~ cd sub-web-modify `
`docker build . -t  sub-web-modify`
```
➜  sub-web-modify git:(master) docker images
REPOSITORY                                    TAG           IMAGE ID       CREATED          SIZE
sub-web-modify                                latest        cc4ca3567acb   12 minutes ago   27.6MB
```
`docker run -d -p 58080:80 --restart always --name sub-web-modify sub-web-modify:latest`